### PR TITLE
updated forecast days default and max

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -275,11 +275,13 @@
                     {
                         "name": "forecast_days",
                         "in": "query",
-                        "description": "The number of days for the sales forecast. Default is 14 if not provided. Max is 14, mainly based on limit of Weather API forecasts",
+                        "description": "The number of days for the sales forecast. The max is 7, based on limit of Weather API forecasts.",
                         "required": false,
                         "schema": {
                             "type": "integer",
-                            "default": 14
+                            "default": 7,
+                            "minimum": 1,
+                            "maximum": 7
                         }
                     },
                     {


### PR DESCRIPTION
The Weather API we're using is currently only giving us 7 days of forecasts, so we'll have to limit the forecast days of our API to match that max. 