### PR TITLE
Updates 3

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -80,6 +80,11 @@
                         "description": "A unique id for the resource. For stores, it may be the store id.",
                         "example": "store_32353"
                     },
+                    "store_name": {
+                        "type": "string",
+                        "description": "A unique identifier of the store for the resource. This can be used in conjunction with the resource_id to uniquely identify a resource across all stores.",
+                        "example": "revolution-gz"
+                    },
                     "status": {
                         "type": "string",
                         "description": "The status of the model",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -327,19 +327,6 @@
                         "example": "%5B%7B%22date%22%3A%222023-07-04%22%2C%22amount%22%3A500%7D%2C%7B%22date%22%3A%222023-07-05%22%2C%22amount%22%3A600%7D%5D"
                     },
                     {
-                        "name": "forecast_type (placeholder)",
-                        "in": "query",
-                        "description": "If the type of the model is 'menu_item', then you can determine whether the forecast should be in units or revenue. Models for 'category' or 'store' types only return revenue. Accepts 'units' or 'revenue'. Defaults to 'revenue'.",
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "units",
-                                "revenue"
-                            ],
-                            "default": "revenue"
-                        }
-                    },
-                    {
                         "name": "current_price (placeholder)",
                         "in": "query",
                         "description": "Optional, if forecast_type is 'revenue'. The current price of the menu item. Discarded if forecast_type is 'units'. By default, the last known price will be used.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -105,29 +105,19 @@
                         ],
                         "example": "revenue"
                     },
-                    "training_data": {
+                    "location": {
                         "type": "object",
-                        "description": "Details about the training data.",
+                        "description": "The location of the store. This info is used to retrieve weather and holiday data",
                         "properties": {
-                            "filename": {
+                            "city": {
                                 "type": "string",
-                                "description": "The filename of the training data.",
-                                "example": "training_data_gz.csv"
+                                "description": "The city where the store is located.",
+                                "example": "guangzhou"
                             },
-                            "n_rows": {
-                                "type": "integer",
-                                "description": "The number of rows in the training data.",
-                                "example": 1000
-                            },
-                            "n_features": {
-                                "type": "integer",
-                                "description": "The number of features in the training data.",
-                                "example": 30
-                            },
-                            "target_column": {
+                            "country": {
                                 "type": "string",
-                                "description": "The target column in the training data.",
-                                "example": "Net Sales"
+                                "description": "The country where the store is located.",
+                                "example": "CN"
                             }
                         }
                     },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -477,7 +477,7 @@
         "/models": {
             "get": {
                 "summary": "List all models",
-                "description": "Returns a list of trained models. A model is built for every resource (menu item, category, store, etc). Models are trained on previously provided sales data, and also include external data sources such as weather data and public holidays. ",
+                "description": "Returns a list of trained models. A model is built for every resource (menu item, category, store, etc). Models are trained on previously provided sales data, and also include external data sources such as weather data and public holidays. Models are only trained on resources that have over 30 data points.",
                 "security": [
                     {
                         "BearerAuth": []

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -299,9 +299,9 @@
                         }
                     },
                     {
-                        "name": "manual_adjustment (placeholder)",
+                        "name": "manual_adjustment",
                         "in": "query",
-                        "description": "An array of objects containing dates and manual adjustment amounts for sales predictions, typically used when the user has scheduled catering, reservations with large groups, or other known sales-increasing events.",
+                        "description": "A URL-safe string that represents a JSON array of objects. Each object represents a manual adjustment and should contain 'date' and 'amount' keys. The 'date' key should correspond to a string that represents a date in the 'YYYY-MM-DD' format. The 'amount' key should correspond to a number, representing the amount to adjust the sales prediction for the specified date. The amount will follow the unit specified under the models' `output_type`. This parameter is typically used when the user has scheduled catering, reservations with large groups, or other known sales-increasing events. To use this parameter, create your array of adjustment objects, convert it to a JSON string using a method like JSON.stringify in JavaScript, then encode the string to make it URL-safe.",
                         "required": false,
                         "schema": {
                             "type": "array",
@@ -311,20 +311,20 @@
                                     "date": {
                                         "type": "string",
                                         "format": "date",
-                                        "description": "The date of the manual adjustment."
+                                        "description": "The date of the manual adjustment. Should be in 'YYYY-MM-DD' format."
                                     },
-                                    "adjustment": {
+                                    "amount": {
                                         "type": "number",
-                                        "description": "The amount to adjust the sales prediction for the specified date. Give it in unit sales"
+                                        "description": "The amount to adjust the sales prediction for the specified date, given in the unit specified under the model's `output_type`."
                                     }
                                 },
                                 "required": [
                                     "date",
-                                    "adjustment"
-                                ],
-                                "default": []
+                                    "amount"
+                                ]
                             }
-                        }
+                        },
+                        "example": "%5B%7B%22date%22%3A%222023-07-04%22%2C%22amount%22%3A500%7D%2C%7B%22date%22%3A%222023-07-05%22%2C%22amount%22%3A600%7D%5D"
                     },
                     {
                         "name": "forecast_type (placeholder)",


### PR DESCRIPTION
- Removed `forecast_type` parameter, because this parameter is actually baked into the model you choose. For `menu_item` models, if you want to choose either `revenue` or `units` as the forecast type, then find the relevant model for that `menu_item` with the correct forecast type using `/models` route, and call `/prediction` with the right model.
- Added instructions on how to provide `manual_adjustment` parameter. Needs to be URL-safe string that represents JSON array of objects.
- removed `training_data` from `Models`
- Added `location` to `Models`. This helps clarify the weather and holiday data.
- Added field for `store_name`. This is necessary to identify uniqueness between resources across stores.
- Added clarification on model training requirements. Resources require at least 30 data points.